### PR TITLE
Fixed error in SUR objective and numerical issues.

### DIFF
--- a/pycombina/_binary_approximation.py
+++ b/pycombina/_binary_approximation.py
@@ -19,6 +19,7 @@
 # along with pycombina. If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import warnings
 import numpy as np
 import numpy.matlib as npm
 from typing import Union
@@ -377,11 +378,13 @@ class BinApprox(BinApproxBase):
 
     def _set_off_state(self, off_state_included: bool) -> None:
 
-        #if off_state_included and \
-        #    not np.all(np.sum(self._b_rel, axis = 0) == 1.0):
-
-        #    raise ValueError("The sum of relaxed binary controls per time point " + \
-        #        "must be exactly 1, or off_state_included must be set to False.")
+        if off_state_included:
+            sums = np.sum(self._b_rel, axis=0)
+            tol = (self._b_rel.shape[0] + 1) * max(np.finfo(sums.dtype).eps, self._binary_threshold)
+            
+            if np.any(np.logical_or(sums > 1.0 + tol, sums < 1.0 - tol)):
+                warnings.warn("The sum of relaxed binary controls per time point " + \
+                    "must be exactly 1, or off_state_included must be set to False.")
 
         self._off_state_included = off_state_included
 

--- a/pycombina/_binary_approximation.py
+++ b/pycombina/_binary_approximation.py
@@ -189,7 +189,7 @@ class BinApproxBase(ABC):
 
         except AttributeError:
 
-            return (self._t[-1] - self._t[0]) * np.ones(self.n_c)
+            return np.full(self.n_c, np.inf)
 
 
     @property
@@ -205,7 +205,7 @@ class BinApproxBase(ABC):
 
         except AttributeError:
 
-            return (self._t[-1] - self._t[0]) * np.ones(self.n_c)
+            return np.full(self.n_c, np.inf)
 
 
     @property
@@ -377,11 +377,11 @@ class BinApprox(BinApproxBase):
 
     def _set_off_state(self, off_state_included: bool) -> None:
 
-        if off_state_included and \
-            not np.all(np.sum(self._b_rel, axis = 0) == 1.0):
+        #if off_state_included and \
+        #    not np.all(np.sum(self._b_rel, axis = 0) == 1.0):
 
-            raise ValueError("The sum of relaxed binary controls per time point " + \
-                "must be exactly 1, or off_state_included must be set to False.")
+        #    raise ValueError("The sum of relaxed binary controls per time point " + \
+        #        "must be exactly 1, or off_state_included must be set to False.")
 
         self._off_state_included = off_state_included
 

--- a/pycombina/_combina_sur.py
+++ b/pycombina/_combina_sur.py
@@ -107,6 +107,7 @@ class CombinaSUR():
 
         b_bin = np.zeros((self._binapprox_p.n_c, self._binapprox_p.n_t))
         eta_i = np.zeros(self._binapprox_p.n_c)
+        eta = 0.0
 
         for i in range(self._binapprox_p.n_t):
 
@@ -123,7 +124,7 @@ class CombinaSUR():
             b_bin[b_active][i] = 1
 
             eta_i[b_active] =  eta_i[b_active] - 1 * self._binapprox_p.dt[i] 
-            eta = abs(max(eta_i, key = abs))
+            eta = max(eta, np.abs(eta_i).max())
         
         self._binapprox_p._b_bin = b_bin
         self._binapprox_p._eta = eta

--- a/test/input_test.py
+++ b/test/input_test.py
@@ -18,6 +18,8 @@
 # along with pycombina. If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+import warnings
+
 import numpy as np
 
 from pycombina._binary_approximation import BinApprox
@@ -34,11 +36,40 @@ class InputTest(unittest.TestCase):
 
     def test_single_control_sos1_violated(self):
 
-        T = np.array([0, 1, 2, 3])
-        b_rel = np.array([0.1, 0.3, 0.2])
+        with warnings.catch_warnings(record=True) as w:
+            T = np.array([0, 1, 2, 3])
+            b_rel = np.array([0.1, 0.3, 0.2])
+            BinApprox(T, b_rel, off_state_included = True)
 
-        self.assertRaises(ValueError, BinApprox, T, b_rel, off_state_included = True)
+            self.assertEqual(len(w), 1)
+            self.assertIs(w[0].category, UserWarning)
 
+    def test_manual_extend_sos1_fulfilled(self):
+        for run_idx in range(50):
+            num_ctrl = np.random.randint(1, 100)
+            num_time = np.random.randint(10, 1000)
+
+            T = np.sort(np.random.rand(num_time))
+            b_rel = np.empty((num_ctrl, num_time - 1))
+            for i in range(b_rel.shape[0]):
+                b_rel[i, :] = (1.0 - b_rel[:i, :].sum(0)) * np.random.rand(num_time - 1)
+
+            with warnings.catch_warnings(record=True) as w:
+                BinApprox(T, np.vstack([b_rel, 1.0 - b_rel.sum(0)]), off_state_included=True)
+                self.assertEqual(len(w), 0)
+
+    def test_manual_scale_sos1_fulfilled(self):
+        for run_idx in range(50):
+            num_ctrl = np.random.randint(2, 100)
+            num_time = np.random.randint(10, 1000)
+
+            T = np.sort(np.random.rand(num_time))
+            b_rel = np.random.rand(num_ctrl, num_time - 1) / num_ctrl
+            b_rel = np.true_divide(b_rel, b_rel.sum(0))
+
+            with warnings.catch_warnings(record=True) as w:
+                BinApprox(T, b_rel, off_state_included=True)
+                self.assertEqual(len(w), 0)
 
     def test_single_control_invalid_dimensions(self):
 


### PR DESCRIPTION
Changes:
    - Reported rounding objective in SUR is now maximum over
      cumulative error at all times rather than only at end of
      time horizon.
    - Removed "sum equals one" check in BinApprox due to numerical
      issues with floating point numbers returned by relaxation solver.
    - Replaced default values for max uptimes with infinity to avoid
      triggering constraints due to numerical errors.