### PR TITLE
Min_down_times not (properly) working in BnB solver

### DIFF
--- a/src/combina_bnb_solver/CombinaBnBSolver.cpp
+++ b/src/combina_bnb_solver/CombinaBnBSolver.cpp
@@ -239,7 +239,7 @@ void CombinaBnBSolver::compute_child_node_properties(
                 
             }
 
-            min_down_time_child[i] -= dt[*depth_child];
+            min_down_time_child[i] = fmax(0, min_down_time_child[i] - dt[*depth_child]);
         }
 
         min_up_time_fulfilled += dt[*depth_child];
@@ -256,6 +256,7 @@ void CombinaBnBSolver::compute_child_node_properties(
 
         sigma_child[b_active_parent]++;
         sigma_child[b_active_child]++;
+        min_down_time_child[b_active_parent]=min_down_time[b_active_parent];
 
         if (sigma_child[b_active_parent] == n_max_switches[b_active_parent]) {
 


### PR DESCRIPTION
There has been a bug with min_down_times in the BnB solver: min_down_time appeared to be negative and not properly initiated (and therefore not working) in previous version.
- Modified function: "compute_child_node_properties"