### PR TITLE
Removing the automatic insertion of a state if sum(b_rel[i])<1, due to:

### DIFF
--- a/examples/combina_example_1.py
+++ b/examples/combina_example_1.py
@@ -27,10 +27,11 @@ data = pl.loadtxt("data/data_example_1.csv", delimiter=" ", skiprows=1)
 
 t = data[:,0]
 b_rel = data[:-1, 1]
-max_switches = [4]
+b_rel = pl.vstack([b_rel, 1-b_rel])
 
-binapprox = pycombina.BinApprox(t=t, b_rel=b_rel, \
-    binary_threshold=1e-3, off_state_included=False)
+max_switches = [4, t.size]
+
+binapprox = pycombina.BinApprox(t=t, b_rel=b_rel, binary_threshold=1e-3)
 
 binapprox.set_n_max_switches(n_max_switches=max_switches)
 
@@ -40,8 +41,8 @@ combina.solve(verbosity=2)
 b_bin = pl.squeeze(binapprox.b_bin)
 
 pl.figure()
-pl.step(t[:-1], b_rel, label="b_rel", color="C0", linestyle="dashed", where="post")
-pl.step(t[:-1], b_bin, label="b_bin", color="C0", where="post")
+pl.step(t[:-1], b_rel[0,:], label="b_rel", color="C0", linestyle="dashed", where="post")
+pl.step(t[:-1], b_bin[0,:], label="b_bin", color="C0", where="post")
 pl.xlabel("t")
 pl.ylabel("b")
 pl.legend(loc="upper left")

--- a/examples/lotka_volterra_multimode.py
+++ b/examples/lotka_volterra_multimode.py
@@ -32,17 +32,16 @@ b_rel = data[:-1:dN, 3:]
 
 max_switches = [5, 2, 3]
 
-binapprox = pycombina.BinApprox(t=t, b_rel=b_rel, \
-    binary_threshold=1e-3, off_state_included=True)
+binapprox = pycombina.BinApprox(t=t, b_rel=b_rel, binary_threshold=1e-3)
 
 binapprox.set_n_max_switches(n_max_switches=max_switches)
-#binapprox.set_valid_controls_for_interval((0, 2), [1,0,0])
+# binapprox.set_valid_controls_for_interval((0, 2), [0,0,1])
 #binapprox.set_valid_control_transitions(0, [1,0,1])
 #binapprox.set_min_up_times([2.0, 2.0, 2.0])
 #binapprox.set_cia_norm("row_sum_norm")
 
 combina = pycombina.CombinaBnB(binapprox)
-combina.solve()
+combina.solve(max_iter= int(5e6), max_cpu_time=3.6e3)
 
 b_bin = pl.asarray(binapprox.b_bin)
 

--- a/pycombina/_combina_bnb.py
+++ b/pycombina/_combina_bnb.py
@@ -105,7 +105,8 @@ class CombinaBnB():
 
         else:
 
-            b_bin_pre = int(self._binapprox_p.b_bin_pre[np.where(self._binapprox_p.b_bin_pre == 1)])
+            b_bin_pre = int(np.where(self._binapprox_p.b_bin_pre == 1)[0])
+
         self._bnb_solver = CombinaBnBSolver( \
                 self._binapprox_p.dt.tolist(), \
                 self._binapprox_p.b_rel.tolist(), \

--- a/test/combina_test.py
+++ b/test/combina_test.py
@@ -126,23 +126,24 @@ class CombinaTestSingleInput(object):
         0.3383625190626729, 0.3383625129203459, 0.33836250815864527,
          0.3383625047650565, 0.338362502730721, 0.33836250205035523])
     
+    b_rel = np.vstack([b_rel, 1-b_rel])
 
-    T = 240 * np.arange(0, b_rel.size+1)
-    n_max_switches = 4
+    T = 240 * np.arange(0, b_rel.shape[1]+1)
+    n_max_switches = [4, T.size]
 
-    binapprox = BinApprox(T, b_rel, binary_threshold = 1e-3, off_state_included = False)
+    binapprox = BinApprox(T, b_rel, binary_threshold = 1e-3)
     binapprox.set_n_max_switches(n_max_switches)
 
 
     def test_check_binary_solution(self):
 
         b_bin = self.binapprox.b_bin
-        assert_array_equal(np.squeeze(b_bin), self.b_bin_check)
+        assert_array_equal(np.squeeze(b_bin[0,:]), self.b_bin_check)
 
 
     def test_check_objective(self):
 
-        b_bin = np.squeeze(self.binapprox.b_bin)
+        b_bin = np.squeeze(self.binapprox.b_bin[0,:])
         eta = self.binapprox.eta
 
         Tg = self.T[1:] - self.T[:-1]
@@ -150,7 +151,7 @@ class CombinaTestSingleInput(object):
         
         for k, b_bin_k in enumerate(b_bin):
 
-            eta_check_k = abs(sum([Tg[j] * (self.b_rel[j] - b_bin[j]) for j in range(k)]))
+            eta_check_k = abs(sum([Tg[j] * (self.b_rel[0][j] - b_bin[j]) for j in range(k)]))
 
             if eta_check_k > eta_check:
 
@@ -161,11 +162,11 @@ class CombinaTestSingleInput(object):
 
     def test_check_n_max_switches(self):
 
-        b_bin = np.squeeze(self.binapprox.b_bin)
+        b_bin = np.squeeze(self.binapprox.b_bin[0,:])
 
         n_switches = np.sum(np.absolute(b_bin[1:] - b_bin[:-1]))
 
-        self.assertTrue(n_switches <= self.n_max_switches)
+        self.assertTrue(n_switches <= self.n_max_switches[0])
 
 
 class CombinaTestSingleInputBnB(unittest.TestCase, CombinaTestSingleInput):

--- a/test/input_test.py
+++ b/test/input_test.py
@@ -26,23 +26,16 @@ from pycombina._binary_approximation import BinApprox
 
 class InputTest(unittest.TestCase):
 
-    def test_single_control_sos1_fulfilled(self):
-
-        T = np.array([0, 1, 2, 3])
-        b_rel = np.array([0.1, 0.3, 0.2])
-
-        BinApprox(T, b_rel, off_state_included = False)
-
-
     def test_single_control_sos1_violated(self):
 
         with warnings.catch_warnings(record=True) as w:
             T = np.array([0, 1, 2, 3])
             b_rel = np.array([0.1, 0.3, 0.2])
-            BinApprox(T, b_rel, off_state_included = True)
+            BinApprox(T, b_rel)
 
             self.assertEqual(len(w), 1)
             self.assertIs(w[0].category, UserWarning)
+
 
     def test_manual_extend_sos1_fulfilled(self):
         for run_idx in range(50):
@@ -55,8 +48,9 @@ class InputTest(unittest.TestCase):
                 b_rel[i, :] = (1.0 - b_rel[:i, :].sum(0)) * np.random.rand(num_time - 1)
 
             with warnings.catch_warnings(record=True) as w:
-                BinApprox(T, np.vstack([b_rel, 1.0 - b_rel.sum(0)]), off_state_included=True)
+                BinApprox(T, np.vstack([b_rel, 1.0 - b_rel.sum(0)]))
                 self.assertEqual(len(w), 0)
+
 
     def test_manual_scale_sos1_fulfilled(self):
         for run_idx in range(50):
@@ -68,7 +62,7 @@ class InputTest(unittest.TestCase):
             b_rel = np.true_divide(b_rel, b_rel.sum(0))
 
             with warnings.catch_warnings(record=True) as w:
-                BinApprox(T, b_rel, off_state_included=True)
+                BinApprox(T, b_rel)
                 self.assertEqual(len(w), 0)
 
     def test_single_control_invalid_dimensions(self):
@@ -100,15 +94,7 @@ class InputTest(unittest.TestCase):
         T = np.array([0, 2, 1, 3])
         b_rel = np.array([[0.1, 0.3, 0.3], [0.9, 0.7, 0.7]])
 
-        self.assertRaises(ValueError, BinApprox, T, b_rel, off_state_included = True)
-
-
-    def test_multiple_controls_sos1_fulfilled_auto(self):
-
-        T = np.array([0, 2, 1, 3])
-        b_rel = np.array([[0.1, 0.3, 0.3], [0.2, 0.4, 0.5]])
-
-        self.assertRaises(ValueError, BinApprox, T, b_rel, off_state_included = False)
+        self.assertRaises(ValueError, BinApprox, T, b_rel)
 
 
     def test_multiple_controls_sos1_violated(self):
@@ -116,7 +102,7 @@ class InputTest(unittest.TestCase):
         T = np.array([0, 2, 1, 3])
         b_rel = np.array([[0.1, 0.3, 0.3], [0.3, 0.4, 0.5]])
 
-        self.assertRaises(ValueError, BinApprox, T, b_rel,  off_state_included = True)
+        self.assertRaises(ValueError, BinApprox, T, b_rel)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* When automatically inserting an additional state, it is not
  automatically clear when such an "off_state" is allowed to be active,
  how long, etc. but can at the same time not be specified by the user;
  this caused problems, e. g.,  when using the set_valid_control_for_interval
  function to ensure minimum up time compliance within an MPC loop.
* As there is no general way to determine the constraints fur such
  additional states, I am removing the automatic insertion from pycombina,
  so that the user must now always include and specify the relaxed binaries
  such that sum(b_rel[i]=1), and according conditions and constraints,
* Also, the name "off_state" ist not very general, as it can be any state
  that has not been specified.