### PR TITLE
Quick fix for issue #9.

### DIFF
--- a/src/combina_bnb_solver/CombinaBnBSolver.cpp
+++ b/src/combina_bnb_solver/CombinaBnBSolver.cpp
@@ -318,10 +318,10 @@ NodePtr CombinaBnBSolver::create_or_fathom_child_node(const NodePtr& parent_node
 
 void CombinaBnBSolver::run_bnb() {
 
-    clock_t t_start;
-    clock_t t_update;
-    clock_t t_current;
-    clock_t t_end;
+    std::clock_t t_start;
+    std::clock_t t_update;
+    std::clock_t t_current;
+    std::clock_t t_end;
     
     if (verbosity > 0) {
         py::gil_scoped_acquire lock;
@@ -431,9 +431,9 @@ void CombinaBnBSolver::run_bnb() {
 }
 
 
-bool CombinaBnBSolver::termination_criterion_reached(int n_iter, clock_t t_start) {
+bool CombinaBnBSolver::termination_criterion_reached(int n_iter, std::clock_t t_start) {
 
-    clock_t t_current = clock();
+    std::clock_t t_current = clock();
 
     return ((n_iter >= max_iter) || 
         ((double(t_current - t_start) / CLOCKS_PER_SEC) >= max_cpu_time) ||

--- a/src/combina_bnb_solver/CombinaBnBSolver.hpp
+++ b/src/combina_bnb_solver/CombinaBnBSolver.hpp
@@ -24,6 +24,7 @@
 #ifndef __COMBINA_BNB_SOLVER_HPP
 #define __COMBINA_BNB_SOLVER_HPP
 
+#include <ctime>
 #include <map>
 #include <vector>
 
@@ -108,7 +109,7 @@ private:
         std::vector<double> const & eta_child, double const lb_child);
 
     void run_bnb();
-    bool termination_criterion_reached(int n_iter, clock_t t_start);
+    bool termination_criterion_reached(int n_iter, std::clock_t t_start);
     void set_new_best_node(const NodePtr& active_node);
     void display_solution_update(bool solution_update, double runtime);
     void add_nodes_to_queue(const NodePtr& parent_node);

--- a/src/combina_bnb_solver/NodeQueue.cpp
+++ b/src/combina_bnb_solver/NodeQueue.cpp
@@ -21,7 +21,11 @@
  */
 
 #include <algorithm>
+#include <iterator>
 #include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "NodeQueue.hpp"
 #include "queues/BestFirstNodeQueue.hpp"


### PR DESCRIPTION
This adds the includes that should fix issue #9. I can't test this because I do not have an MSVC setup, but they certainly do not appear to negatively impact compilability on my system. I have also prepended `std::` to all appearances of `clock_t` since that is the "official" C++ way of using that type.