### PR TITLE
Use cvxpy to abstract MILP solver

### DIFF
--- a/pycombina/__init__.py
+++ b/pycombina/__init__.py
@@ -23,14 +23,11 @@ import os
 from ._binary_approximation import BinApprox
 
 try:
-    import gurobipy
-
-    if gurobipy.gurobi.version() < (8, 0, 0):
-        raise ImportError
+    import cvxpy
 
     from ._combina_milp import CombinaMILP
 except ImportError:
-    print("- gurobipy version > 8.0.0 not found, CombinaMILP disabled.\n")
+    print("- cvxpy not found, CombinaMILP disabled.\n")
 
 try:
     from ._combina_bnb import CombinaBnB

--- a/pycombina/__init__.py
+++ b/pycombina/__init__.py
@@ -41,4 +41,3 @@ try:
     from ._combina_sur import CombinaSUR
 except ImportError:
     print("- Sum-Up-Rounding solver extension not found, CombinaSUR disabled.\n")
-

--- a/pycombina/_combina_milp.py
+++ b/pycombina/_combina_milp.py
@@ -32,7 +32,7 @@ class CombinaMILP():
     using mixed-integer linear programming and Gurobi.
 
     The following options of :class:`pycombina.BinApprox` are supported:
-    
+
     - Maximum number of switches
     - Minimum up-times
     - Minimum down-times
@@ -85,7 +85,7 @@ class CombinaMILP():
         self._eta_sym = self._model.addVar(vtype = "C", name = "eta")
 
         if (self._binapprox_p.cia_norm == "column_sum_norm") or (self._binapprox_p.cia_norm == "row_sum_norm"):
-            
+
             self._eta_sym_indiv = {}
 
             for i in range(self._binapprox_p.n_c):
@@ -94,12 +94,12 @@ class CombinaMILP():
 
                     self._eta_sym_indiv[(i,j)] = self._model.addVar( \
                         vtype = "C", name = "eta_sym_indiv".format((i,j)))
-                 
+
         self._b_bin_sym = {}
         self._s = {}
 
         for i in range(self._binapprox_p.n_c):
-        
+
             for j in range(-1,self._binapprox_p.n_t-1):
 
                 self._s[(i,j)] = self._model.addVar(vtype = "C", \
@@ -118,11 +118,11 @@ class CombinaMILP():
 
         for i in range(self._binapprox_p.n_c):
 
-            if self._binapprox_p.b_bin_pre.sum() == 1: 
+            if self._binapprox_p.b_bin_pre.sum() == 1:
 
                 self._model.addConstr(self._b_bin_sym[(i,-1)] == int(self._binapprox_p.b_bin_pre[i]))
 
-        
+
     def _setup_objective(self):
 
         print("  - Objective ... ", end = "", flush = True)
@@ -209,7 +209,7 @@ class CombinaMILP():
 
         print("done")
 
-         
+
     def _setup_maximum_switching_constraints(self):
 
         print("  - Maximum switching constraints ... ", end = "", flush = True)
@@ -230,14 +230,14 @@ class CombinaMILP():
                 self._model.addConstr((self._b_bin_sym[(i,-1)] - self._b_bin_sym[(i,self._binapprox_p.n_t-1)] + \
                     gp.quicksum([self._s[(i,j)] for j in range(-1,self._binapprox_p.n_t-1)])) <= sigma_max_i)
                 self._model.addConstr((self._b_bin_sym[(i,self._binapprox_p.n_t-1)] - self._b_bin_sym[(i,-1)] + \
-                    gp.quicksum([self._s[(i,j)] for j in range(-1,self._binapprox_p.n_t-1)])) <= sigma_max_i) 
+                    gp.quicksum([self._s[(i,j)] for j in range(-1,self._binapprox_p.n_t-1)])) <= sigma_max_i)
 
             else:
 
                 self._model.addConstr((1 - self._b_bin_sym[(i,-1)] - self._b_bin_sym[(i,self._binapprox_p.n_t-1)] + \
                     gp.quicksum([self._s[(i,j)] for j in range(-1, self._binapprox_p.n_t-1)])) <= sigma_max_i)
                 self._model.addConstr((self._b_bin_sym[(i,-1)] + self._b_bin_sym[(i,self._binapprox_p.n_t-1)] - 1 + \
-                    gp.quicksum([self._s[(i,j)] for j in range(-1, self._binapprox_p.n_t-1)])) <= sigma_max_i)  
+                    gp.quicksum([self._s[(i,j)] for j in range(-1, self._binapprox_p.n_t-1)])) <= sigma_max_i)
 
         print("done")
 
@@ -246,7 +246,7 @@ class CombinaMILP():
 
         print("  - Dwell time constraints ... ", end = "", flush = True)
 
-        dt_sums = np.zeros((self._binapprox_p.n_t, self._binapprox_p.n_t)) 
+        dt_sums = np.zeros((self._binapprox_p.n_t, self._binapprox_p.n_t))
 
         for j in range(self._binapprox_p.n_t):
 
@@ -254,13 +254,13 @@ class CombinaMILP():
 
                 for k in range(j+1,self._binapprox_p.n_t):
 
-                    dt_sums[j][k] =  dt_sums[j][k-1] + self._binapprox_p.dt[k] 
+                    dt_sums[j][k] =  dt_sums[j][k-1] + self._binapprox_p.dt[k]
 
         for i in range(self._binapprox_p.n_c):
 
             for k in range(1,self._binapprox_p.n_t):
 
-                if dt_sums[0][k-1] < self._binapprox_p.min_up_times[i]:  
+                if dt_sums[0][k-1] < self._binapprox_p.min_up_times[i]:
                     self._model.addLConstr(gp.LinExpr([1.0, -1.0], [self._b_bin_sym[(i,k)], \
                         self._b_bin_sym[(i,0)]]), gp.GRB.GREATER_EQUAL, 0.0)
 
@@ -268,7 +268,7 @@ class CombinaMILP():
 
                 for k in range(j+1,self._binapprox_p.n_t):
 
-                    if dt_sums[j][k-1] < self._binapprox_p.min_up_times[i]:  
+                    if dt_sums[j][k-1] < self._binapprox_p.min_up_times[i]:
                         self._model.addLConstr(gp.LinExpr([1.0, -1.0, 1.0], [self._b_bin_sym[(i,k)], \
                             self._b_bin_sym[(i,j)], self._b_bin_sym[(i,j-1)]]), gp.GRB.GREATER_EQUAL, 0.0)
 
@@ -288,7 +288,7 @@ class CombinaMILP():
             for j in range(1,self._binapprox_p.n_t):
 
                 self._model.addConstr(1 >= self._b_bin_sym[(i,j)] + \
-                    gp.quicksum(self._b_bin_sym[(l,j-1)] for l in range(self._binapprox_p.n_c) if self._binapprox_p.b_adjacencies[l][i] == 0)) 
+                    gp.quicksum(self._b_bin_sym[(l,j-1)] for l in range(self._binapprox_p.n_c) if self._binapprox_p.b_adjacencies[l][i] == 0))
 
         print("done")
 
@@ -314,7 +314,7 @@ class CombinaMILP():
         print("Setting up MILP model for Gurobi:")
 
         start_time = time.time()
-        
+
         self._setup_model_variables()
         self._setup_b_bin_pre_variables()
         self._setup_objective()
@@ -406,4 +406,3 @@ class CombinaMILP():
         self._set_solution()
 
         print("\n")
-

--- a/pycombina/_combina_milp.py
+++ b/pycombina/_combina_milp.py
@@ -18,8 +18,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with pycombina. If not, see <http://www.gnu.org/licenses/>.
 
+import cvxpy as cp
 import numpy as np
-import gurobipy as gp
 import time
 
 from ._binary_approximation import BinApprox, BinApproxPreprocessed
@@ -55,6 +55,13 @@ class CombinaMILP():
         11: "User interrupt"
     }
 
+    def __init__(self, binapprox: BinApprox) -> None:
+
+        self._constraints = []
+        self._problem = None
+        self._apply_preprocessing(binapprox)
+        self._setup_milp(binapprox)
+
 
     @property
     def status(self):
@@ -73,18 +80,13 @@ class CombinaMILP():
         self._binapprox_p = BinApproxPreprocessed(binapprox)
 
 
-    def _initialize_milp(self):
-
-        self._model = gp.Model("Combinatorial Integral Approximation MILP")
-
-
     def _setup_model_variables(self):
 
         print("\n  - Optimization variables ... ", end = "", flush = True)
 
-        self._eta_sym = self._model.addVar(vtype = "C", name = "eta")
+        self._eta_sym = cp.Variable(name="eta")
 
-        if (self._binapprox_p.cia_norm == "column_sum_norm") or (self._binapprox_p.cia_norm == "row_sum_norm"):
+        if self._binapprox_p.cia_norm in {"column_sum_norm", "row_sum_norm"}:
 
             self._eta_sym_indiv = {}
 
@@ -92,8 +94,7 @@ class CombinaMILP():
 
                 for j in range(self._binapprox_p.n_t):
 
-                    self._eta_sym_indiv[(i,j)] = self._model.addVar( \
-                        vtype = "C", name = "eta_sym_indiv".format((i,j)))
+                    self._eta_sym_indiv[(i,j)] = cp.Variable(name=f"eta_sym_indiv_{i}_{j}")
 
         self._b_bin_sym = {}
         self._s = {}
@@ -102,14 +103,14 @@ class CombinaMILP():
 
             for j in range(-1,self._binapprox_p.n_t-1):
 
-                self._s[(i,j)] = self._model.addVar(vtype = "C", \
-                    name = "s_{0}".format((i,j)))
+                self._s[(i,j)] = cp.Variable(name=f"s_{i}_{j}")
 
-                self._b_bin_sym[(i,j)] = self._model.addVar( \
-                    vtype = "B", name = "b_bin_{0}".format((i,j)))
+                self._b_bin_sym[(i,j)] = cp.Variable(name=f"b_bin_{(i,j)}", boolean=True)
 
-            self._b_bin_sym[(i, self._binapprox_p.n_t-1)] = self._model.addVar( \
-                vtype = "B", name = "b_bin_{0}".format((i,self._binapprox_p.n_t-1)))
+            self._b_bin_sym[(i, self._binapprox_p.n_t-1)] = cp.Variable(
+                name = f"b_bin_{(i,self._binapprox_p.n_t-1)}",
+                boolean=True
+            )
 
         print("done")
 
@@ -120,16 +121,9 @@ class CombinaMILP():
 
             if self._binapprox_p.b_bin_pre.sum() == 1:
 
-                self._model.addConstr(self._b_bin_sym[(i,-1)] == int(self._binapprox_p.b_bin_pre[i]))
-
-
-    def _setup_objective(self):
-
-        print("  - Objective ... ", end = "", flush = True)
-
-        self._model.setObjective(self._eta_sym)
-
-        print("done")
+                self._constraints.append(
+                    self._b_bin_sym[(i,-1)] == int(self._binapprox_p.b_bin_pre[i])
+                )
 
 
     def _setup_approximation_inequalities(self):
@@ -140,16 +134,16 @@ class CombinaMILP():
 
             for i in range(self._binapprox_p.n_c):
 
-                lhs = gp.LinExpr()
+                lhs = 0.0
                 rhs = 0.0
 
                 for j in range(self._binapprox_p.n_t):
 
-                    lhs.addTerms(self._binapprox_p.dt[j], self._b_bin_sym[(i,j)])
+                    lhs += self._binapprox_p.dt[j] * self._b_bin_sym[(i,j)]
                     rhs += self._binapprox_p.dt[j] * self._binapprox_p.b_rel[i][j]
 
-                    self._model.addLConstr(lhs + self._eta_sym, gp.GRB.GREATER_EQUAL, rhs)
-                    self._model.addLConstr(lhs - self._eta_sym, gp.GRB.LESS_EQUAL, rhs)
+                    self._constraints.append(lhs + self._eta_sym >= rhs)
+                    self._constraints.append(lhs - self._eta_sym <= rhs)
 
                     # self._model.addConstr(self._eta_sym >= sum( \
                     #     [self._binapprox_p.dt[k] * (self._binapprox_p.b_rel[i][k] - self._b_bin_sym[(i,k)]) for k in range(j+1)]))
@@ -160,41 +154,43 @@ class CombinaMILP():
 
             for i in range(self._binapprox_p.n_c):
 
-                lhs = gp.LinExpr()
+                lhs = 0.0
                 rhs = 0.0
 
                 for j in range(self._binapprox_p.n_t):
 
-                    lhs.addTerms(self._binapprox_p.dt[j], self._b_bin_sym[(i,j)])
+                    lhs += self._binapprox_p.dt[j] * self._b_bin_sym[(i,j)]
                     rhs += self._binapprox_p.dt[j] * self._binapprox_p.b_rel[i][j]
 
-                    self._model.addLConstr(lhs + self._eta_sym_indiv[(i,j)], gp.GRB.GREATER_EQUAL, rhs)
-                    self._model.addLConstr(lhs - self._eta_sym_indiv[(i,j)], gp.GRB.LESS_EQUAL, rhs)
+                    self._constraints.append(lhs + self._eta_sym_indiv[(i,j)] >= rhs)
+                    self._constraints.append(lhs - self._eta_sym_indiv[(i,j)] <= rhs)
 
             for j in range(self._binapprox_p.n_t):
 
-                self._model.addConstr(self._eta_sym >= gp.quicksum( \
-                        [self._eta_sym_indiv[(i,j)]  for i in range(self._binapprox_p.n_c)]))
+                self._constraints.append(
+                    self._eta_sym >= cp.sum([self._eta_sym_indiv[(i,j)] for i in range(self._binapprox_p.n_c)])
+                )
 
         elif self._binapprox_p.cia_norm == "row_sum_norm":
 
             for i in range(self._binapprox_p.n_c):
 
-                lhs = gp.LinExpr()
+                lhs = 0.0
                 rhs = 0.0
 
                 for j in range(self._binapprox_p.n_t):
 
-                    lhs.addTerms(self._binapprox_p.dt[j], self._b_bin_sym[(i,j)])
+                    lhs += self._binapprox_p.dt[j] * self._b_bin_sym[(i,j)]
                     rhs += self._binapprox_p.dt[j] * self._binapprox_p.b_rel[i][j]
 
-                    self._model.addLConstr(lhs + self._eta_sym_indiv[(i,j)], gp.GRB.GREATER_EQUAL, rhs)
-                    self._model.addLConstr(lhs - self._eta_sym_indiv[(i,j)], gp.GRB.LESS_EQUAL, rhs)
+                    self._constraints.append(lhs + self._eta_sym_indiv[(i,j)] >= rhs)
+                    self._constraints.append(lhs - self._eta_sym_indiv[(i,j)] <= rhs)
 
             for i in range(self._binapprox_p.n_c):
 
-                self._model.addConstr(self._eta_sym >= gp.quicksum( \
-                        [self._eta_sym_indiv[(i,j)]  for j in range(self._binapprox_p.n_t)]))
+                self._constraints.append(
+                    self._eta_sym >= cp.sum([self._eta_sym_indiv[(i,j)] for j in range(self._binapprox_p.n_t)])
+                )
 
         print("done")
 
@@ -205,7 +201,9 @@ class CombinaMILP():
 
         for j in range(self._binapprox_p.n_t):
 
-            self._model.addConstr(gp.quicksum([self._b_bin_sym[(i,j)] for i in range(self._binapprox_p.n_c)]) == 1)
+            self._constraints.append(
+                cp.sum([self._b_bin_sym[(i,j)] for i in range(self._binapprox_p.n_c)]) == 1
+            )
 
         print("done")
 
@@ -218,26 +216,22 @@ class CombinaMILP():
 
             for j in range(-1,self._binapprox_p.n_t-1):
 
-                self._model.addConstr(self._s[(i,j)] >= self._b_bin_sym[(i,j)] - self._b_bin_sym[(i,j+1)])
-                self._model.addConstr(self._s[(i,j)] >= -self._b_bin_sym[(i,j)] + self._b_bin_sym[(i,j+1)])
-                self._model.addConstr(self._s[(i,j)] <= self._b_bin_sym[(i,j)] + self._b_bin_sym[(i,j+1)])
-                self._model.addConstr(self._s[(i,j)] <= 2 - self._b_bin_sym[(i,j)] - self._b_bin_sym[(i,j+1)])
+                self._constraints.append(self._s[(i,j)] >= self._b_bin_sym[(i,j)] - self._b_bin_sym[(i,j+1)])
+                self._constraints.append(self._s[(i,j)] >= -self._b_bin_sym[(i,j)] + self._b_bin_sym[(i,j+1)])
+                self._constraints.append(self._s[(i,j)] <= self._b_bin_sym[(i,j)] + self._b_bin_sym[(i,j+1)])
+                self._constraints.append(self._s[(i,j)] <= 2 - self._b_bin_sym[(i,j)] - self._b_bin_sym[(i,j+1)])
 
         for i, sigma_max_i in enumerate(self._binapprox_p.n_max_switches):
 
             if sigma_max_i % 2 == 0:
 
-                self._model.addConstr((self._b_bin_sym[(i,-1)] - self._b_bin_sym[(i,self._binapprox_p.n_t-1)] + \
-                    gp.quicksum([self._s[(i,j)] for j in range(-1,self._binapprox_p.n_t-1)])) <= sigma_max_i)
-                self._model.addConstr((self._b_bin_sym[(i,self._binapprox_p.n_t-1)] - self._b_bin_sym[(i,-1)] + \
-                    gp.quicksum([self._s[(i,j)] for j in range(-1,self._binapprox_p.n_t-1)])) <= sigma_max_i)
+                self._constraints.append((self._b_bin_sym[(i,-1)] - self._b_bin_sym[(i,self._binapprox_p.n_t-1)] + cp.sum([self._s[(i,j)] for j in range(-1,self._binapprox_p.n_t-1)])) <= sigma_max_i)
+                self._constraints.append((self._b_bin_sym[(i,self._binapprox_p.n_t-1)] - self._b_bin_sym[(i,-1)] + cp.sum([self._s[(i,j)] for j in range(-1,self._binapprox_p.n_t-1)])) <= sigma_max_i)
 
             else:
 
-                self._model.addConstr((1 - self._b_bin_sym[(i,-1)] - self._b_bin_sym[(i,self._binapprox_p.n_t-1)] + \
-                    gp.quicksum([self._s[(i,j)] for j in range(-1, self._binapprox_p.n_t-1)])) <= sigma_max_i)
-                self._model.addConstr((self._b_bin_sym[(i,-1)] + self._b_bin_sym[(i,self._binapprox_p.n_t-1)] - 1 + \
-                    gp.quicksum([self._s[(i,j)] for j in range(-1, self._binapprox_p.n_t-1)])) <= sigma_max_i)
+                self._constraints.append((1 - self._b_bin_sym[(i,-1)] - self._b_bin_sym[(i,self._binapprox_p.n_t-1)] + cp.sum([self._s[(i,j)] for j in range(-1, self._binapprox_p.n_t-1)])) <= sigma_max_i)
+                self._constraints.append((self._b_bin_sym[(i,-1)] + self._b_bin_sym[(i,self._binapprox_p.n_t-1)] - 1 + cp.sum([self._s[(i,j)] for j in range(-1, self._binapprox_p.n_t-1)])) <= sigma_max_i)
 
         print("done")
 
@@ -261,20 +255,17 @@ class CombinaMILP():
             for k in range(1,self._binapprox_p.n_t):
 
                 if dt_sums[0][k-1] < self._binapprox_p.min_up_times[i]:
-                    self._model.addLConstr(gp.LinExpr([1.0, -1.0], [self._b_bin_sym[(i,k)], \
-                        self._b_bin_sym[(i,0)]]), gp.GRB.GREATER_EQUAL, 0.0)
+                    self._constraints.append(self._b_bin_sym[(i,k)] - self._b_bin_sym[(i,0)] >= 0.0)
 
             for j in range(1,self._binapprox_p.n_t):
 
                 for k in range(j+1,self._binapprox_p.n_t):
 
                     if dt_sums[j][k-1] < self._binapprox_p.min_up_times[i]:
-                        self._model.addLConstr(gp.LinExpr([1.0, -1.0, 1.0], [self._b_bin_sym[(i,k)], \
-                            self._b_bin_sym[(i,j)], self._b_bin_sym[(i,j-1)]]), gp.GRB.GREATER_EQUAL, 0.0)
+                        self._constraints.append(self._b_bin_sym[(i,k)] - self._b_bin_sym[(i,j)] + self._b_bin_sym[(i,j-1)] >= 0.0)
 
                     if dt_sums[j][k-1] < self._binapprox_p.min_down_times[i]:
-                        self._model.addLConstr(gp.LinExpr([1.0, 1.0, -1.0], [self._b_bin_sym[(i,k)], \
-                            self._b_bin_sym[(i,j-1)], self._b_bin_sym[(i,j)]]), gp.GRB.LESS_EQUAL, 1.0)
+                        self._constraints.append(self._b_bin_sym[(i,k)] + self._b_bin_sym[(i,j-1)] - self._b_bin_sym[(i,j)] <= 1.0)
 
         print("done")
 
@@ -287,8 +278,8 @@ class CombinaMILP():
 
             for j in range(1,self._binapprox_p.n_t):
 
-                self._model.addConstr(1 >= self._b_bin_sym[(i,j)] + \
-                    gp.quicksum(self._b_bin_sym[(l,j-1)] for l in range(self._binapprox_p.n_c) if self._binapprox_p.b_adjacencies[l][i] == 0))
+                self._constraints.append(1 >= self._b_bin_sym[(i,j)] +
+                    cp.sum([self._b_bin_sym[(l,j-1)] for l in range(self._binapprox_p.n_c) if self._binapprox_p.b_adjacencies[l][i] == 0]))
 
         print("done")
 
@@ -303,7 +294,7 @@ class CombinaMILP():
 
                 if self._binapprox_p.b_valid[i][j] == 0:
 
-                    self._model.addConstr(self._b_bin_sym[(i,j)]  == 0)
+                    self._constraints.append(self._b_bin_sym[(i,j)] == 0)
 
         print("done")
 
@@ -311,13 +302,12 @@ class CombinaMILP():
 
     def _setup_milp(self, binapprox: BinApprox) -> None:
 
-        print("Setting up MILP model for Gurobi:")
+        print("Setting up MILP model:")
 
         start_time = time.time()
 
         self._setup_model_variables()
         self._setup_b_bin_pre_variables()
-        self._setup_objective()
         self._setup_approximation_inequalities()
         self._setup_sos1_constraints()
         self._setup_maximum_switching_constraints()
@@ -326,16 +316,8 @@ class CombinaMILP():
         self._setup_valid_controls_for_intervals_constraints()
 
 
-        print("\nModel set up finished after", \
+        print("\nModel set up finished after",
             round(time.time() - start_time, 2), "seconds\n")
-
-
-    def __init__(self, binapprox: BinApprox) -> None:
-
-        self._apply_preprocessing(binapprox)
-        self._initialize_milp()
-        self._setup_milp(binapprox)
-
 
 
     def _setup_warm_start(self, use_warm_start: bool) -> None:
@@ -351,30 +333,20 @@ class CombinaMILP():
             #         self._b_bin_sym[(i,j)].start = self._binapprox_p._b_bin[i][j]
 
 
-    def _run_solver(self, gurobi_opts: dict) -> None:
-
-        for gurobi_opt in gurobi_opts.keys():
-
-            try:
-
-                self._model.setParam(gurobi_opt, gurobi_opts[gurobi_opt])
-
-            except ValueError:
-
-                raise ValueError("Values of solver options must be of numerical type.")
-
-        self._model.optimize()
+    def _run_solver(self, solver: str, opts: dict) -> None:
+        self._problem = cp.Problem(cp.Minimize(self._eta_sym), self._constraints)
+        self._problem.solve(solver=solver, verbose=True, **opts)
 
 
     def _retrieve_solutions(self):
 
-        self._binapprox_p._eta = self._model.getVarByName(self._eta_sym.VarName).x
+        self._binapprox_p._eta = self._eta_sym.value
         self._binapprox_p._b_bin = []
 
         for i in range(self._binapprox_p.n_c):
 
-            self._binapprox_p._b_bin.append([abs(round(self._model.getVarByName( \
-                self._b_bin_sym[(i,j)].VarName).x)) for j in range(self._binapprox_p.n_t)])
+            self._binapprox_p._b_bin.append([np.abs(np.round(
+                self._b_bin_sym[(i,j)].value)) for j in range(self._binapprox_p.n_t)])
 
 
     def _set_solution(self):
@@ -384,7 +356,7 @@ class CombinaMILP():
         self._binapprox.set_eta(self._binapprox_p.eta)
 
 
-    def solve(self, use_warm_start: bool = False , gurobi_opts: dict = {}):
+    def solve(self, solver: str = "CBC", use_warm_start: bool = False, opts: dict = {}):
 
         '''
         Solve the combinatorial integral approximation problem.
@@ -392,7 +364,7 @@ class CombinaMILP():
         :param use_warm_start: If a binary solution is already contained in the
                                given binary approximation problem, use it to
                                warm-start the solver.
-        :param gurobi_opts: Gurobi solver options (cf. Gurobi manual), examples are:
+        :param opts: Solver options examples (for Gurobi) are:
 
             - **MIPGap**: relative MIP optimality gap; when solution found fulfilling
               the gap, Gurobi stops. Default: 0.0001
@@ -401,7 +373,7 @@ class CombinaMILP():
         '''
 
         self._setup_warm_start(use_warm_start = use_warm_start)
-        self._run_solver(gurobi_opts = gurobi_opts)
+        self._run_solver(solver = solver, opts = opts)
         self._retrieve_solutions()
         self._set_solution()
 


### PR DESCRIPTION
This switches the code from using Gurobi to using cvxpy as an abtraction for the MILP solver.

Upsides:
* It becomes possible to use the MILP approach if you (like me) don't have a copy of Gurobi. 
* The open source CBC solver seems to work well, but a person could use Gurobi, FICO XPRESS, GLPK MI, or any of a number of other solvers.
* cvxpy has an elegant interface which allows this switch with fairly minimal code changes.

Downsides:
* cvxpy takes some time to compile problems into a form it can pass to the solver (eg, CBC). In the case of the test code, this took 83s on my pretty powerful machine. Once compiled, a problem can be quickly resolved by changing parameters, though pycombina doesn't seem to have this eventuality built in.