### PR TITLE
merge develop into master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install packages via pip
-      run: pip install numpy unittest2
-    - name: Build and test
-      run: python setup.py test
+      run: pip install numpy pytest
+    - name: Build and install
+      run: python setup.py install
+    - name: Test
+      run: pytest -v test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Install packages via pip
       run: pip install numpy pytest
     - name: Build and install
-      run: python setup.py install
+      run: pip install -e .
     - name: Test
       run: pytest -v test

--- a/pycombina/_binary_approximation.py
+++ b/pycombina/_binary_approximation.py
@@ -21,7 +21,6 @@
 import os
 import warnings
 import numpy as np
-import numpy.matlib as npm
 from typing import Union
 
 from abc import ABC
@@ -726,8 +725,7 @@ class BinApprox(BinApproxBase):
             b_bin_valid = b_bin_valid.T
 
         idx_interval = np.logical_and(self.t[:-1] >= dt[0], self.t[:-1] < dt[1])
-        self._b_valid[:, idx_interval] = \
-            npm.repmat(b_bin_valid, 1, np.sum(idx_interval))
+        self._b_valid[:, idx_interval] = b_bin_valid
 
 
     def set_valid_control_transitions(self, b_i: int, \


### PR DESCRIPTION
Some maintenance work:

- Update pybind11
- Remove an unnecessary numpy repmat call (fixes a deprecation warning)
- Use pytest for testing in Github actions (fixes a deprecation warning)